### PR TITLE
Fix mdast-attributes for API changes in mdast-util-from-markdown v2.

### DIFF
--- a/packages/mdast-attributes/index.ts
+++ b/packages/mdast-attributes/index.ts
@@ -15,7 +15,8 @@ export function mdastAttributes(): FromMarkdownExtension {
     exit: {
       attrs(token) {
         const attrs = this.resume()
-        const node = this.exit(token)
+        const node = this.stack[this.stack.length - 1]
+        this.exit(token)
         // @ts-expect-error Assume `node` is a `AttrsNode`.
         node.value = attrs
       }


### PR DESCRIPTION
This is backwards-compatible with v1.

Fixes #4 