### PR TITLE
Improve type annotations

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,26 +1,32 @@
 import type {Root} from 'mdast'
+import type {Extension as FromMarkdownExtension} from 'mdast-util-from-markdown'
 import type {Processor, Transformer} from 'unified'
 import {micromarkAttributes} from './packages/micromark-attributes/index.js'
 import {mdastAttributes} from './packages/mdast-attributes/index.js'
 import {attributesTransformer} from './packages/attributes-transformer/index.js'
+import {AttributesExtension} from './util/types.js'
+
+interface AttributesData {
+  micromarkExtensions?: AttributesExtension[]
+  fromMarkdownExtensions?: FromMarkdownExtension[]
+}
 
 /**
  * Plugin to support attributes like markdown-it-attrs
  * [text](https://test.com){target=_blank}
  */
 export default function remarkAttributes(
-  this: Processor,
+  this: Processor<Root, Root, Root, string>,
   options = {mdx: false}
 ): Transformer<Root> {
-  const data: Record<string, unknown> = this.data()
+  const data = this.data() as AttributesData
 
-  /**
-   * @param {string} key
-   * @param {unknown} value
-   */
-  function add(key: string, value: unknown) {
-    const list = (data[key] || (data[key] = [])) as unknown[]
-    list.unshift(value)
+  function add<K extends keyof AttributesData>(
+    key: K,
+    value: AttributesData[K][0]
+  ) {
+    data[key] ||= []
+    data[key].unshift(value)
   }
 
   add('micromarkExtensions', micromarkAttributes({escaped: options.mdx}))

--- a/packages/attributes-transformer/index.ts
+++ b/packages/attributes-transformer/index.ts
@@ -3,6 +3,7 @@ import {Node, Parent} from 'unist'
 import parseAttrs from 'md-attr-parser'
 
 type AttrsNode = {
+  type: 'attrs'
   value?: string
 } & Node
 
@@ -22,11 +23,11 @@ export function attributesTransformer(node: any): void {
     node,
     (node, index, parent) =>
       ['paragraph'].includes(node.type) && parent?.type === 'listItem',
-    (node: Parent<AttrsNode>, index, parent) => {
+    (node: Parent<Node | AttrsNode>, index, parent) => {
       const children = node.children
 
       const ids = children.filter(
-        (child: {type: string}) => child.type === 'attrs'
+        (child: {type: string}): child is AttrsNode => child.type === 'attrs'
       )
 
       if (!ids || ids.length === 0) return

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,11 +8,10 @@
     "moduleResolution": "nodenext",
     "noImplicitAny": false,
     "declaration": true,
-    "skipLibCheck": true,
-    "typeRoots": [
-      "./typings",
-      "node_modules/@types"
-    ],
+    "paths": {
+      "md-attr-parser": ["./typings/md-attr-parser.d.ts"]
+    },
+    "skipLibCheck": true
   },
   "ts-node": {
     "esm": true,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,1 +1,0 @@
-declare module 'md-attr-parser'

--- a/typings/md-attr-parser.d.ts
+++ b/typings/md-attr-parser.d.ts
@@ -1,0 +1,22 @@
+// md-attr-parser 1.3.0
+
+export interface Properties {
+  id: string
+  class: string[]
+  [K: string]: string | string[]
+}
+
+export interface ParseResult {
+  prop: Properties
+  eaten: string
+}
+
+export interface Config {
+  defaultValue?: () => string
+}
+
+export default function parse(
+  value: string,
+  indexNext?: number,
+  config?: Config
+): ParseResult


### PR DESCRIPTION
* The Processor data can be (more) well-typed.
* The AttrsNode can be inferred.
* "typeRoots" is allegedly meant for globals: https://github.com/microsoft/TypeScript/issues/22217#issuecomment-369783776
