### PR TITLE
Fix infinite loop on empty attribute block `{}`

### DIFF
--- a/packages/micromark-attributes/index.ts
+++ b/packages/micromark-attributes/index.ts
@@ -169,8 +169,15 @@ export function micromarkAttributes(
                       effects.consume(code)
                       effects.enter('attrs')
                       effects.enter('chunkString', {contentType: 'string'})
-                      return inside
+                      return firstInside
                     }
+                  }
+
+                  function firstInside(code: Code) {
+                    if (code === codes.rightCurlyBrace) {
+                      return nok(code)
+                    }
+                    return inside(code)
                   }
 
                   function inside(code: Code) {

--- a/test/positive/empty-attribute-block/input.md
+++ b/test/positive/empty-attribute-block/input.md
@@ -1,0 +1,7 @@
+{}
+
+![](){}
+
+![alt](https://example.com/image.jpg){}
+
+text with an {} empty block

--- a/test/positive/empty-attribute-block/output.html
+++ b/test/positive/empty-attribute-block/output.html
@@ -1,0 +1,4 @@
+<p>{}</p>
+<p><img src="" alt="">{}</p>
+<p><img src="https://example.com/image.jpg" alt="alt">{}</p>
+<p>text with an {} empty block</p>


### PR DESCRIPTION
Fixes #11.

### Problem

An empty attribute block `{}` in phrasing content sends the non-escaped tokenizer into an **infinite synchronous loop at parse time** — the process hangs with no error, and because the loop is synchronous it can't be caught by a timeout. `processor.parse('{}')` alone is enough to reproduce. It affects `0.3.2` through the latest `0.4.4`.

These all hang: `{}`, `![](){}`, `![alt](url){}`, `x {} y`.

### Root cause

In `packages/micromark-attributes/index.ts` (`syntaxExtension`), on `{` the tokenizer enters a `chunkString` (`contentType: 'string'`) and then, when the very next character is `}`, exits it having consumed nothing. That produces a **zero-length `chunkString` subcontent token** (start === end), and micromark's subtokenizer never advances past it, so it loops forever.

`{ }` (whitespace) does not hang because the space gives the `chunkString` non-zero length; the escaped/`mdx` variant is also unaffected because it requires `\}` to close and never emits the empty token.

### Fix

Add a `firstInside` state that `nok`s an immediate `}`, so an empty block is rejected and the braces are left as literal text — matching `markdown-it-attrs`, which treats `{}` as a no-op.

```
{}                 -> <p>{}</p>
![](){}            -> <p><img src="" alt="">{}</p>
```

Non-empty attributes, headings, code fences, whitespace-only `{ }`, and the `mdx` variant are all unchanged.

### Testing

Added a regression fixture `test/positive/empty-attribute-block/` (auto-discovered by the existing "fixtures with md" test). Full suite: **58 tests, 58 pass** (was 57), no regressions.

> [!IMPORTANT]
> This fix was found and prepared using AI with human review.
