### PR TITLE
Fix unbalanced token stream on `{...}` attribute blocks (expected last token to be open)

### DIFF
--- a/packages/micromark-attributes/index.ts
+++ b/packages/micromark-attributes/index.ts
@@ -185,14 +185,15 @@ export function micromarkAttributes(
                           codes.leftCurlyBrace
                         ].includes(code as any)
                       ) {
-                        effects.consume(code)
                         return nok(code)
                       }
 
                       if (code === codes.rightCurlyBrace) {
                         effects.exit('chunkString')
                         effects.exit('attrs')
+                        effects.enter('attributesMarker')
                         effects.consume(code)
+                        effects.exit('attributesMarker')
                         effects.exit('attributes')
                         return ok(code)
                       }

--- a/test/dev-assertion-check.mjs
+++ b/test/dev-assertion-check.mjs
@@ -1,0 +1,42 @@
+// Renders `{...}` attribute blocks through the built plugin with micromark's
+// dev-build assertions enabled. Run via `node --conditions=development`, which
+// selects micromark's `dev/` builds (the ones that assert token invariants).
+//
+// remark-attributes used to emit an unbalanced token stream for attribute
+// blocks — it `consume`d before `nok` on the terminator path, and closed the
+// `}` without a matching open — which tripped the assertion
+// `expected last token to be open` (see issue #10). micromark strips these
+// assertions from its production build, so the malformed stream is silently
+// accepted there and this is only observable under the `development` condition.
+//
+// Exits 0 if every case renders; exits non-zero (letting the assertion surface)
+// on regression.
+import {unified} from 'unified'
+import remarkParse from 'remark-parse'
+import remarkRehype from 'remark-rehype'
+import rehypeStringify from 'rehype-stringify'
+import remarkAttributes from '../dist/index.js'
+
+const cases = [
+  {input: '# Heading {#id}', includes: 'id="id"'},
+  {input: 'some text{.green}', includes: 'class="green"'},
+  {input: '[link](/x){.btn target=_blank}', includes: 'class="btn"'}
+]
+
+const processor = unified()
+  .use(remarkParse)
+  .use(remarkAttributes)
+  .use(remarkRehype)
+  .use(rehypeStringify)
+
+for (const {input, includes} of cases) {
+  const output = String(await processor.process(input))
+  if (!output.includes(includes)) {
+    process.stderr.write(
+      `unexpected output for ${JSON.stringify(input)}: ${output}\n`
+    )
+    process.exit(2)
+  }
+}
+
+process.stdout.write('ok')

--- a/test/index.ts
+++ b/test/index.ts
@@ -4,6 +4,7 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
+import {spawnSync} from 'node:child_process'
 import test from 'tape'
 import {readSync} from 'to-vfile'
 import {unified} from 'unified'
@@ -28,6 +29,34 @@ test('directive()', (t) => {
     unified().use(remarkAttributes).freeze()
   }, 'should not throw if without parser or compiler')
 
+  t.end()
+})
+
+test('attribute blocks satisfy micromark token invariants (dev assertions)', (t) => {
+  // The `{...}` attribute tokenizer must emit a balanced token stream. When it
+  // doesn't, micromark's dev build throws `expected last token to be open`
+  // (issue #10); its production build silently accepts the malformed stream, so
+  // the defect is only observable under the `development` export condition.
+  // Render in a child process with that condition enabled and assert it exits
+  // cleanly. Requires the build output (`npm run build` runs first under `test`).
+  if (!fs.existsSync(path.join('dist', 'index.js'))) {
+    t.skip('needs dist/ — run `npm run build` first')
+    t.end()
+    return
+  }
+
+  const result = spawnSync(
+    process.execPath,
+    ['--conditions=development', path.join('test', 'dev-assertion-check.mjs')],
+    {encoding: 'utf8'}
+  )
+
+  t.equal(
+    result.status,
+    0,
+    'renders `{...}` attribute blocks under micromark dev assertions without throwing' +
+      (result.status === 0 ? '' : '\n' + (result.stderr || result.stdout))
+  )
   t.end()
 })
 

--- a/util/types.d.ts
+++ b/util/types.d.ts
@@ -7,7 +7,7 @@ import type {
   TokenizeContext,
   TokenType
 } from 'micromark-util-types'
-export type AttributesTokenType = TokenType | 'attributes' | 'attrs'
+export type AttributesTokenType = TokenType | 'attributes' | 'attrs' | 'attributesMarker'
 /**
  * Open a token.
  *

--- a/util/types.ts
+++ b/util/types.ts
@@ -8,7 +8,7 @@ import type {
   TokenType
 } from 'micromark-util-types'
 
-export type AttributesTokenType = TokenType | 'attributes' | 'attrs'
+export type AttributesTokenType = TokenType | 'attributes' | 'attrs' | 'attributesMarker'
 
 /**
  * Open a token.


### PR DESCRIPTION
Fixes #10.

### Problem

The non-escaped `{...}` attribute tokenizer emits an **unbalanced token stream**, which trips micromark's dev-build assertion `expected last token to be open` when parsing any attribute block, e.g. `# Heading {#id}` or `some text{.green}`.

Two spots in `inside` (in `packages/micromark-attributes/index.ts`) violate the invariant:

1. **Terminator path** (CR / LF / `\` / `{` / EOF): it calls `effects.consume(code)` and *then* `nok(code)`. Consuming inside a construct that is about to be rejected leaves the attempt in an inconsistent state; `effects.attempt` should be allowed to rewind cleanly.
2. **`}` success path**: it `consume`s the closing brace without a surrounding token, so the last event before the `consume` is an `exit` (of `attrs`), not an `enter` — which is exactly what the assertion checks.

micromark strips these assertions from its **production** build, so the malformed stream is silently accepted there and the defect is invisible unless you run under the `development` export condition (e.g. Vitest, or `node --conditions=development`).

### Fix

- Terminator path: drop the unbalanced `effects.consume(code)` before `nok(code)`.
- `}` path: wrap the closing-brace `consume` in a fresh `attributesMarker` enter/exit pair, so the last event before the `consume` is an `enter`.
- Add `attributesMarker` to `AttributesTokenType`.

Output is unchanged in production; this only fixes the token structure so the invariant holds.

### Test

`test/dev-assertion-check.mjs` renders a few attribute blocks and `test/index.ts` runs it in a child process under `node --conditions=development`, asserting it exits cleanly. Before the fix that child throws `expected last token to be open`; after it, it renders. An ordinary output test can't tell the two apart because the production build produces identical HTML either way.

### Scope

The escaped (`mdx: true`) variant of the same function has the identical antipattern but isn't exercised here (default `mdx: false`), so it's left untouched to keep the change minimal — worth a follow-up if MDX mode matters to you.

> [!IMPORTANT]
> This fix was found and prepared using AI with human review.
